### PR TITLE
Update example output to be consistent with Joern v1.1.188

### DIFF
--- a/docs.joern.io/docs/c-syntaxtree.mdx
+++ b/docs.joern.io/docs/c-syntaxtree.mdx
@@ -27,7 +27,7 @@ Throughout this article, we are using variations of the following
 small sample code snippet taken (taken from [this
 paper](https://fabs.codeminers.org/papers/2014-ieeesp.pdf)):
 
-```bash
+```java
 val code = """
 void foo () {
   int x = source();
@@ -49,14 +49,14 @@ function `sink` on line 5.
 We can import this code snippet directly on the Joern shell.
 
 
-```bash
+```java
 importCode.c.fromString(code)
 ```
 
 Once imported, we can plot the abstract syntax tree of `foo` to get a
 first idea of what an abstract syntax tree is.
 
-```bash
+```java
 cpg.method.name("foo").plotDotAst
 ```
 
@@ -92,7 +92,7 @@ The most basic [traversal](traversal-basics) that you can
 execute on any AST node is `ast`, which traverses to all nodes of the
 AST rooted in the node. For example,
 
-```bash
+```java
 cpg.method("foo").ast.l
 ```
 
@@ -101,13 +101,13 @@ node is also the root of a subtree, you can also think of this
 operation as an enumeration of all subtrees. These can be filtered by
 type. For example,
 
-```
+```java
 cpg.method("foo").ast.isCall.code.l
 ```
 
 gives you all outgoing calls from `foo` while
 
-```
+```java
 cpg.method("foo").ast.isControlStructure.code.l
 ```
 
@@ -115,11 +115,11 @@ gives you all control structures. For method nodes, we also offer
 shorthands for the most common node types. Using these shorthands, the
 two queries can be written as
 
-```
+```java
 cpg.method("foo").call.code.l
 ```
 and
-```
+```java
 cpg.method("foo).controlStructure.code.l
 ```
 respectively.
@@ -130,7 +130,7 @@ running example, consider for example the situation where it is known
 that calls to `source` return values that an attacker can
 influence.
 
-```bash
+```java
 cpg.call.name("source").inAstMinusLeaf.isCall.name(".*assignment.*").argument(1).l
 ```
 
@@ -148,7 +148,7 @@ on them via AST-queries is common, we have created a decorator
 language to simplify these queries. In practice, we would write the
 following query that is equivalent to the former query.
 
-```bash
+```java
 cpg.call("source").inAssignment.target.l
 ```
 
@@ -167,27 +167,25 @@ tree. The tree consists of two sub trees, one that holds the condition
 `x < MAX` and another that holds the statements in the
 `if`-block. Conditions can be selected as follows:
 
-```bash
+```java
 cpg.method("foo").controlStructure.condition.code.l
 => List("x < MAX")
 ```
 
 The body of the if-statement can be selected using `whenTrue`:
 
-```bash
+```java
 cpg.method("foo").controlStructure.whenTrue.l
-res16: List[AstNode] = List(
+res41: List[AstNode] = List(
   Block(
-	id -> 17L,
-	code -> "",
-	order -> 2,
-	argumentIndex -> 2,
-	typeFullName -> "void",
-	dynamicTypeHintFullName -> List(),
-	lineNumber -> Some(5),
-	columnNumber -> Some(4),
-	depthFirstOrder -> None,
-	internalFlags -> None
+    id -> 1000110L,
+    argumentIndex -> 2,
+    argumentName -> None,
+    code -> "",
+    columnNumber -> Some(value = 4),
+    lineNumber -> Some(value = 5),
+    order -> 2,
+    typeFullName -> "void"
   )
 )
 ```
@@ -196,7 +194,7 @@ For `if-else` constructs, `whenFalse` returns the else block, however,
 since no `else` block exists in our example, an empty list is
 returned:
 
-```
+```java
 cpg.method("foo").controlStructure.whenFalse.l
 => List[AstNode] = List()
 ```
@@ -205,7 +203,7 @@ As each of the nodes returned by `.ast` are also roots of syntax
 trees, we can identify nested structures by chaining basic
 operations.
 
-```
+```java
 cpg.method("foo").controlStructure.whenTrue.ast.isCall.code.l
 => List[String] = List("y = 2*x", "sink(y)", "2*x")
 ```
@@ -223,9 +221,9 @@ to identify functions that call `source` but they do not include a
 check against `MAX`. The following query achieves this:
 
 
-```bash
-cpg.method.filterNot(_.controlStructure(".*MAX.*"))
-		  .filter(_.callee.name(".*source.*")).l
+```java
+cpg.method.filter(_.controlStructure(".*MAX.*").isEmpty)
+          .filter(_.callee.name(".*source.*").nonEmpty).l
 => List()
 ```
 
@@ -275,27 +273,27 @@ nested in a `while` block, we could use the following query:
 
 ```bash
 cpg.call("sink")
-	.inAst.filter(_.isControlStructure.code("if.*"))
-	.inAst.filter(_.isControlStructure.code("while.*")).l
+	.inAst.isControlStructure.code("if.*")
+	.inAst.isControlStructure.code("while.*").l
 
-=> List[AstNode] = List(
+=> List[ControlStructure] = List(
   ControlStructure(
-	id -> 19L,
-	code -> "while(x++ < MAX)",
-	columnNumber -> Some(2),
-	lineNumber -> Some(9),
-	order -> 3,
-	parserTypeName -> "WhileStatement",
-	argumentIndex -> 3,
-	depthFirstOrder -> None,
-	internalFlags -> None
+    id -> 1000112L,
+    argumentIndex -> 4,
+    argumentName -> None,
+    code -> "while(x++ < MAX)",
+    columnNumber -> Some(value = 2),
+    controlStructureType -> "WHILE",
+    lineNumber -> Some(value = 9),
+    order -> 4,
+    parserTypeName -> "WhileStatement"
   )
 )
 ```
 
 Alternatively, we can walk the tree from its top to achieve the same:
 
-```
+```java
  cpg.method
 	.controlStructure("while.*")
 	.ast.isControlStructure.code("if.*")
@@ -303,22 +301,18 @@ Alternatively, we can walk the tree from its top to achieve the same:
 
 => List[Call] = List(
   Call(
-	id -> 36L,
-	code -> "sink(y)",
-	name -> "sink",
-	order -> 2,
-	methodInstFullName -> None,
-	methodFullName -> "sink",
-	argumentIndex -> 2,
-	dispatchType -> "STATIC_DISPATCH",
-	signature -> "TODO assignment signature",
-	typeFullName -> "ANY",
-	dynamicTypeHintFullName -> List(),
-	lineNumber -> Some(12),
-	columnNumber -> Some(0),
-	resolved -> None,
-	depthFirstOrder -> None,
-	internalFlags -> None
+    id -> 1000129L,
+    argumentIndex -> 3,
+    argumentName -> None,
+    code -> "sink(y)",
+    columnNumber -> Some(value = 8),
+    dispatchType -> "STATIC_DISPATCH",
+    lineNumber -> Some(value = 12),
+    methodFullName -> "sink",
+    name -> "sink",
+    order -> 3,
+    signature -> "TODO",
+    typeFullName -> "<empty>"
   )
 )
 ```

--- a/docs.joern.io/docs/export.md
+++ b/docs.joern.io/docs/export.md
@@ -47,7 +47,7 @@ can do so on the [Joern shell](/shell). To this end, we define
 the following steps on `method` nodes to dump representations in dot
 format.
 
-```
+```java
 cpg.method($name).dotAst.l // output AST in dot format
 cpg.method($name).dotCfg.l // output CFG in dot format
 ...
@@ -57,7 +57,7 @@ cpg.method($name).dotCpg14.l // output CPG'14 in dot format
 You can also plot and view representations using the following
 queries:
 
-```
+```java
 cpg.method($name).plotDotAst // plot AST
 cpg.method($name).ploDotCfg // plot CFG
 ...
@@ -73,7 +73,7 @@ Generate the CPG along with the data flow layer for a sample function
 named `myfunc`.
 
 
-```
+```java
 joern> importCode.c.fromString( """
            int myfunc(int b) {
              int a = 42;
@@ -90,13 +90,13 @@ joern> run.ossdataflow
 
 You can now plot the AST as follows:
 
-```
+```java
 joern> cpg.method("myfunc").plotDotAst 
 ```
 
 You can obtain the dot representation of the AST as well:
 
-```
+```java
 joern> cpg.method("myfunc").dotAst.l
 res4: List[String] = List(
   """digraph myfunc {  
@@ -138,7 +138,7 @@ res4: List[String] = List(
 
 You can also dump all representations into the directory `out` using
 
-```
+```java
 run.dumpast
 run.dumpcfg
 ...

--- a/docs.joern.io/docs/interpreter.mdx
+++ b/docs.joern.io/docs/interpreter.mdx
@@ -12,7 +12,7 @@ Joern can be used in non-interactive mode. You would execute commands and operat
 
 For example, let's say you have a file named `test.sc` with the following contents:
 
-```
+```java
 @main def exec(cpgFile: String, outFile: String) = {
    loadCpg(cpgFile)
    cpg.method.name.l |> outFile

--- a/docs.joern.io/docs/organizing-projects.mdx
+++ b/docs.joern.io/docs/organizing-projects.mdx
@@ -89,15 +89,14 @@ res4: io.shiftleft.repl.JoernProject = Project(
 The active project is the project which contains the Code Property Graph you want to focus your analysis on at a given time. Some important Joern Shell commands always refer to the _current active project_. For example, if you run `cpg.metaData.l`, the return value will be the _META_DATA_ node of the Code Property Graph of the _currently active project_, which in this case, is `x42-c`:
 
 ```java
-joern> cpg.metaData.l 
+joern> cpg.metaData.l
 res5: List[MetaData] = List(
   MetaData(
-    id -> 2L,
+    id -> 1L,
+    hash -> None,
     language -> "C",
-    version -> null,
-    overlays -> List("semanticcpg", "dataflow", "tagging"),
-    policyDirectories -> List(),
-    spid -> None
+    overlays -> List("semanticcpg"),
+    version -> "0.1"
   )
 )
 ```

--- a/docs.joern.io/docs/quickstart.mdx
+++ b/docs.joern.io/docs/quickstart.mdx
@@ -93,16 +93,14 @@ learn a helpful Joern trick: `TAB`-completion. In the Joern prompt,
 type `cpg.`, do not press `ENTER`, but instead press `TAB`. You will
 see a list of available functions `cpg` supports:
 ```java
-joern> cpg. 
-all                            comment                        finding                        local                          newArgumentDescriptorSource    newReturnSource                runScript                      types
-annotation                     configfile                     flow                           member                         newArgumentSink                newTagForMethodsWithFullName   scalaGraph                     write
-argument                       cpg                            graph                          metaData                       newArgumentSource              newTagForParameter             sensitiveType
-arithmetic                     dependency                     help                           method                         newExposedParameterSink        newTagForParameterWithIndex    sensitiveVariable
-assignment                     dom                            id                             methodRef                      newExposedParameterSource      newTagForParameterWithIndexes  sink
-blacklist                      exposedMethod                  identifier                     methodReturn                   newLiteralSource               packagePrefix                  source
-call                           exposedOutputParameter         ioFlow                         namespace                      newMethodSummary               parameter                      tag
-callChain                      exposedParameter               jsp                            namespaceBlock                 newReturnDescriptorSource      read                           transform
-close                          file                           literal                        newArgumentDescriptorSink      newReturnSink                  returns                        typeDecl
+joern> cpg.
+all                comment            goto               literal            namespace          tryBlock
+argument           continue           graph              local              namespaceBlock     typ
+arithmetic         controlStructure   help               member             parameter          typeDecl
+assignment         doBlock            id                 metaData           ret                typeRef
+break              elseBlock          identifier         method             runScript          whileBlock
+call               file               ifBlock            methodRef          switchBlock
+close              forBlock           jumpTarget         methodReturn       tag
 ```
 
 TAB-completion is available for all query language directives, and for
@@ -150,65 +148,77 @@ property. We find exactly one:
 
 ```java
 joern> cpg.call.argument.code("stderr").toList
-res4: List[Call] = List(
+res3: List[Expression] = List(
+  Identifier(
+    id -> 1000118L,
+    argumentIndex -> 1,
+    argumentName -> None,
+    code -> "stderr",
+    columnNumber -> Some(value = 12),
+    lineNumber -> Some(value = 7),
+    name -> "stderr",
+    order -> 1,
+    typeFullName -> "ANY"
+  )
+)
+```
+This query shows that `stderr` is used somewhere in the program, but doesn't give us any more information. Using the query from the previous step, we can use the `astParent` construct to find out more about the surroundings of the `stderr` usage by moving up the hierarchy of the abstract syntax tree that is part of the Code Property Graph. Moving up one level in the AST hierarchy gives us an `fprintf` call:
+
+```java
+joern> cpg.call.argument.code("stderr").astParent.toList
+res4: List[AstNode] = List(
   Call(
-    id -> 24L,
+    id -> 1000117L,
+    argumentIndex -> 1,
+    argumentName -> None,
     code -> "fprintf(stderr, \"It depends!\\n\")",
+    columnNumber -> Some(value = 4),
+    dispatchType -> "STATIC_DISPATCH",
+    lineNumber -> Some(value = 7),
+    methodFullName -> "fprintf",
     name -> "fprintf",
     order -> 1,
-    methodInstFullName -> None,
-    methodFullName -> "fprintf",
-    argumentIndex -> 1,
-    dispatchType -> "STATIC_DISPATCH",
-    signature -> "TODO assignment signature",
-    typeFullName -> "ANY",
-    dynamicTypeHintFullName -> List(),
-    lineNumber -> Some(7),
-    columnNumber -> Some(4),
-    resolved -> None,
-    depthFirstOrder -> Some(-8),
-    internalFlags -> Some(4)
+    signature -> "TODO",
+    typeFullName -> "<empty>"
   )
 )
 ```
 
 With this query we have proven the first part of our problem statement correct, there is a place in the `X42` program that writes to STDERR. Let us move to the second part, the check whether the call that writes something to STDERR is conditional on a value passed as input to the `X42` program. Since we are analyzing a program written in `C`, we will search the Code Property Graph for the conventional `argc` or `argv` parameters of the `main` function as the input that potentially triggers the call which writes to STDERR.
 
-Using the query from the previous step, we can use the `astParent` construct to find out more about the surroundings around the `fprintf` call by moving up in the hierarchy of the abstract syntax tree that is part of the Code Property Graph. Moving up one level in the AST hierarchy gives us a block; not very helpful:
+As before, we can use the `astParent` to move up the AST. Moving up another level in the AST hierarchy gives us a block; not very helpful:
 
 ```java
-joern> cpg.call.argument.code("stderr").astParent.toList
+joern> cpg.call.argument.code("stderr").astParent.astParent.toList
 res5: List[AstNode] = List(
   Block(
-    id -> 23L,
-    code -> "",
-    order -> 2,
+    id -> 1000116L,
     argumentIndex -> 2,
-    typeFullName -> "void",
-    dynamicTypeHintFullName -> List(),
-    lineNumber -> Some(6),
-    columnNumber -> Some(46),
-    depthFirstOrder -> Some(-24),
-    internalFlags -> Some(0)
+    argumentName -> None,
+    code -> "",
+    columnNumber -> Some(value = 46),
+    lineNumber -> Some(value = 6),
+    order -> 2,
+    typeFullName -> "void"
   )
 )
 ```
 
-Another two layers up gives us an if statement, much better:
+Another layer up gives us an if statement, much better:
 
 ```java
-joern> cpg.call.argument.code("stderr").astParent.astParent.astParent.l
+joern> cpg.call.argument.code("stderr").astParent.astParent.astParent.toList
 res6: List[AstNode] = List(
   ControlStructure(
-    id -> 11L,
-    code -> "if (argc > 1 && strcmp(argv[1], \"42\") == 0)",
-    columnNumber -> Some(2),
-    lineNumber -> Some(6),
-    order -> 1,
-    parserTypeName -> "IfStatement",
+    id -> 1000104L,
     argumentIndex -> 1,
-    depthFirstOrder -> None,
-    internalFlags -> None
+    argumentName -> None,
+    code -> "if (argc > 1 && strcmp(argv[1], \"42\") == 0)",
+    columnNumber -> Some(value = 2),
+    controlStructureType -> "IF",
+    lineNumber -> Some(value = 6),
+    order -> 1,
+    parserTypeName -> "IfStatement"
   )
 )
 ```

--- a/docs.joern.io/docs/shell.mdx
+++ b/docs.joern.io/docs/shell.mdx
@@ -45,7 +45,7 @@ queries in order to convert results into the JSON format. This feature can
 be combined with the shell's pipe operators to write results out to
 the file system. For example,
 
-```
+```java
 cpg.method.toJson |> "/tmp/foo.json"
 ```
 
@@ -58,7 +58,7 @@ For an increasing number of languages, the Joern shell allows you to
 read code associated with query results directly on the shell. For
 example, to review all calls to `memcpy`, you can issue:
 
-```bash
+```java
 joern> cpg.method.name("memcpy").callIn.code.l
 
 res5: List[String] = List(
@@ -73,7 +73,7 @@ res5: List[String] = List(
 
 You can also pipe the result list into a pager as follows:
 
-```bash
+```java
 joern> browse(cpg.method.name("memcpy").callIn.code.l)
 ```
 
@@ -124,7 +124,7 @@ You can dynamically load additional scripts at any time.
 
 As an example, let's assume there's a file called `MyScript.sc` that contains only `val elite = 31337`. You can import the script as follows:
 
-```scala
+```java
 import $file.MyScript
 MyScript.elite
 res1: Int = 31337
@@ -136,7 +136,7 @@ To go up one directory, use `^`.
 
 ### Adding Dependencies to the JVM `classpath` Dynamically
 
-```scala
+```java
 // java dependency
 import $ivy.`com.michaelpollmeier:versionsort:1.0.1`
 versionsort.VersionHelper.compare("2.1.0", "2.0.10")
@@ -150,13 +150,13 @@ colordiff.ColorDiff(List("a", "b"), List("a", "bb"))
 
 If the dependencies are not on Maven Central, you can add a resolver:
 
-```scala
+```java
 interp.repositories() ++= Seq(coursierapi.MavenRepository.of("https://shiftleft.jfrog.io/shiftleft/libs-snapshot-local"))
 ```
 
 ### Measuring the Time While Running a Computation
 
-```scala
+```java
 time { 
   println("long running computation")
   Thread.sleep(1000)

--- a/docs.joern.io/docs/traversal-basics.mdx
+++ b/docs.joern.io/docs/traversal-basics.mdx
@@ -79,11 +79,10 @@ joern> cpg.metaData.toList
 res3: List[MetaData] = List(
   MetaData(
     id -> 1L,
+    hash -> None,
     language -> "C",
-    version -> "0.1",
     overlays -> List("semanticcpg"),
-    policyDirectories -> List(),
-    spid -> None
+    version -> "0.1"
   )
 )
 ```
@@ -91,7 +90,7 @@ res3: List[MetaData] = List(
 In the result of this query, we already see the `LANGUAGE` field and that it is `C`. For the sake of completeness and to illustrate property directives, let us add the property directive `language` to the query. Property directives provide access to individual node properties. Each node-type step can be combined with different property directives, and they usually match the properties defined on the node type represented by the node-type step:
 ```java
 joern> cpg.metaData.language.toList 
-res4: List[AnyRef] = "C"
+res4: List[String] = List("C")
 ```
 
 With this last query, we have achieved our goal of executing a traversal which returns the `LANGUAGE` property of the `METADATA` node of the `X42` program.
@@ -119,17 +118,17 @@ int main(int argc, char *argv[]) {
 A commonly used node-type step is `method`, which represents a traversal to all nodes of type `METHOD`. `METHOD` nodes represent declarations of methods, functions or procedures in programs, and one of their properties is `NAME`. All names of all method nodes can thus be determined as follows:
 
 ```java
-joern > cpg.method.name.l 
+joern > cpg.method.name.l
 res4: List[String] = List(
-  "<operator>.logicalAnd",
-  "strcmp",
-  "<operator>.equals",
-  "printf",
+  "main",
   "fprintf",
   "exit",
+  "<operator>.logicalAnd",
+  "<operator>.equals",
   "<operator>.greaterThan",
-  "main",
-  "<operator>.indirectIndexAccess"
+  "strcmp",
+  "<operator>.indirectIndexAccess",
+  "printf"
 )
 ```
 
@@ -184,16 +183,16 @@ _Map Steps_ are traversals that map a set of nodes into a different form given a
 
 ```java
 joern> cpg.method.map(node => (node.isExternal, node.name)).toList
-res6: List[(java.lang.Boolean, String)] = List(
-  (true, "<operator>.logicalAnd"),
-  (true, "strcmp"),
-  (true, "<operator>.equals"),
-  (true, "printf"),
+res6: List[(Boolean, String)] = List(
+  (false, "main"),
   (true, "fprintf"),
   (true, "exit"),
+  (true, "<operator>.logicalAnd"),
+  (true, "<operator>.equals"),
   (true, "<operator>.greaterThan"),
-  (false, "main"),
-  (true, "<operator>.indirectIndexAccess")
+  (true, "strcmp"),
+  (true, "<operator>.indirectIndexAccess"),
+  (true, "printf")
 )
 ```
 
@@ -226,18 +225,18 @@ joern> cpg.method.isExternal(false).name.l
 res103: List[String] = List("main")
 ```
 
-Two useful _Complex Steps_ are `astParent` and `astChildren`, which allow you to steer your traversals through the abstract syntax tree of the program under analysis. Say you'd like to have a query that returns the `CODE` property for all nodes of type `LITERAL` which are AST child nodes of `CALL` nodes that have `println` in their `NAME` property:
+Two useful _Complex Steps_ are `astParent` and `astChildren`, which allow you to steer your traversals through the abstract syntax tree of the program under analysis. Say you'd like to have a query that returns the `CODE` property for all nodes of type `LITERAL` which are AST child nodes of `CALL` nodes that have `printf` in their `NAME` property:
 
 ```java
-joern> cpg.call.name("println").astChildren.isLiteral.code.l 
-res87: List[String] = List("\"What is the meaning of life?\"", "\"It depends!\"")
+joern> cpg.call.name("printf").astChildren.isLiteral.code.l
+res30: List[String] = List("\"What is the meaning of life?\\n\"")
 ```
 
 Or taken the other way around, a query which returns the property of all `CALL` nodes which have AST parent nodes of type `LITERAL` that have their `CODE` property set to `\"What is the meaning of life?\"`:
 
 ```java
 joern> cpg.literal.filter(_.code == "\"What is the meaning of life?\\n\"").astParent.isCall.name.toList
-res100: List[String] = List("println")
+res100: List[String] = List("printf")
 ```
 
 Describing queries in human language tends to sound peculiar. But so would descriptions of bash one-liners, or basic regular expressions if you'd try out that exercise. As long as you understand the individual components of a query, it won't be hard to construct them correctly and understand clearly what they do.
@@ -250,19 +249,17 @@ There are cases in which queries have repetitions in them and become too long. I
 For example, say you'd like to find nodes of type `LITERAL` in `X42`'s Code Property Graph that are directly reachable from the node which represents the `main` method. One way of doing that is by using five `astChildren` _Complex Steps_ in combination with `isLiteral`, which is another _Complex Step_ that filters for AST nodes of type `LITERAL` and maps them to actual `LITERAL` nodes,  plus the `code("42")` _Property Filter Step_:
 
 ```java
-joern> cpg.method.name("main").astChildren.astChildren.astChildren.astChildren.astChildren.isLiteral.code("42").toList 
-res137: List[Literal] = List(
+joern> cpg.method.name("main").astChildren.astChildren.astChildren.astChildren.astChildren.isLiteral.code("42").toList
+res32: List[Literal] = List(
   Literal(
-    id -> 1000000050L,
-    code -> "42",
-    order -> 1,
+    id -> 1000121L,
     argumentIndex -> 1,
-    typeFullName -> "int",
-    dynamicTypeHintFullName -> List(),
-    lineNumber -> Some(5),
-    columnNumber -> None,
-    depthFirstOrder -> None,
-    internalFlags -> None
+    argumentName -> None,
+    code -> "42",
+    columnNumber -> Some(value = 9),
+    lineNumber -> Some(value = 8),
+    order -> 1,
+    typeFullName -> "int"
   )
 )
 ```
@@ -270,19 +267,17 @@ res137: List[Literal] = List(
 The query might do the job, but it is hard to read and change. `repeat-times` makes the query clearer:
 
 ```java
-joern> cpg.method.name("main").repeat(_.astChildren)(_.times(5)).isLiteral.code("42").l 
-res138: List[Literal] = List(
+joern> cpg.method.name("main").repeat(_.astChildren)(_.times(5)).isLiteral.code("42").l
+res33: List[Literal] = List(
   Literal(
-    id -> 1000000050L,
-    code -> "42",
-    order -> 1,
+    id -> 1000121L,
     argumentIndex -> 1,
-    typeFullName -> "int",
-    dynamicTypeHintFullName -> List(),
-    lineNumber -> Some(5),
-    columnNumber -> None,
-    depthFirstOrder -> None,
-    internalFlags -> None
+    argumentName -> None,
+    code -> "42",
+    columnNumber -> Some(value = 9),
+    lineNumber -> Some(value = 8),
+    order -> 1,
+    typeFullName -> "int"
   )
 )
 ```
@@ -290,19 +285,17 @@ res138: List[Literal] = List(
 And even better is another variant of `repeat`, namely `repeat-until`:
 
 ```java
-joern> cpg.method.name("main").repeat(_.astChildren)(_.until(_.isLiteral.code("42"))).l 
-res139: List[AstNode] = List(
+joern> cpg.method.name("main").repeat(_.astChildren)(_.until(_.isLiteral.code("42"))).l
+res34: List[AstNode] = List(
   Literal(
-    id -> 1000000050L,
-    code -> "42",
-    order -> 1,
+    id -> 1000121L,
     argumentIndex -> 1,
-    typeFullName -> "int",
-    dynamicTypeHintFullName -> List(),
-    lineNumber -> Some(5),
-    columnNumber -> None,
-    depthFirstOrder -> None,
-    internalFlags -> None
+    argumentName -> None,
+    code -> "42",
+    columnNumber -> Some(value = 9),
+    lineNumber -> Some(value = 8),
+    order -> 1,
+    typeFullName -> "int"
   )
 )
 ```


### PR DESCRIPTION
# Notes
* Update the types for several code blocks to `java` for consistent styling across pages
* Update example outputs to what is output by the latest Joern release (at the time of writing).
**NOTE:** These commands were run using the built-in fuzzy C frontend. Minor tweaks may be required along with the switch to the new frontend.
* Some queries were broken during at some point, so these have been updated for the new structure.

# Testing
Site was hosted and inspected locally.