### PR TITLE
Remove refs to `passes`/`passesNot` from docs

### DIFF
--- a/docs.joern.io/docs/cpgql/complex-steps.mdx
+++ b/docs.joern.io/docs/cpgql/complex-steps.mdx
@@ -122,5 +122,5 @@ res0: List[String] = List("strcmp(argv[1], \"42\")")
 
 ## Dataflow Steps
 
-_Dataflow Steps_ are _Complex Steps_ which traverse the nodes of a _Code Property Graph_ which represent a program's data-flow. `controlledBy`, `flows`,`passes`, `passesNot`, `source`, `sink`, `reachableBy` are all CPGQL Components that are combined to construct _Dataflow Steps_.
+_Dataflow Steps_ are _Complex Steps_ which traverse the nodes of a _Code Property Graph_ which represent a program's data-flow. `controlledBy`, `flows`,, `source`, `sink`, `reachableBy` are all CPGQL Components that are combined to construct _Dataflow Steps_.
 

--- a/docs.joern.io/docs/cpgql/reference-card.mdx
+++ b/docs.joern.io/docs/cpgql/reference-card.mdx
@@ -72,8 +72,6 @@ title: Reference Card
 | `inCall` | Lists all nodes representing surrounding Call Graph call-sites of the traversed nodes |
 | `locations`      | List of all locations nodes traversed in a given dataflow |
 | `notControlledBy`      | Returns only those flows that are NOT wrapped by a given AST control condition (>, <, =, etc.) |
-| `passesNot`      | Returns only those dataflows that DO NOT pass through a given function/condition as defined in predicate |
-| `passes`      | Returns only those dataflows that pass through a given function/condition as defined in predicate |
 | `reachableBy`      | Find if a given source node is reachable by a sink via a dataflow |
 | `reachableByFlows` | Find paths for flows of data from sinks to sources |
 | `sink`      | List of all nodes identified as potential sensitive sinks the natured of methods, literals, types etc. associated with them |


### PR DESCRIPTION
The steps are not part of the OSS dataflow engine.