### PR TITLE
Make `git clone` copyable

### DIFF
--- a/docs.joern.io/docs/quickstart.mdx
+++ b/docs.joern.io/docs/quickstart.mdx
@@ -23,7 +23,7 @@ analyze. Clone the following git repository which contains a simple
 program named `X42`:
 
 ```bash
-$ git clone https://github.com/ShiftLeftSecurity/x42.git
+git clone https://github.com/ShiftLeftSecurity/x42.git
 ```
 
 Let us start with a problem statement. Show - without running the


### PR DESCRIPTION
When a reader copies the `git clone` command, the `$` will get copied with it.
Even if your target group probably knows how to handle this, why bother with it?