### PR TITLE
Fixing Spelling mistake  at Search Queries

### DIFF
--- a/docs.joern.io/docs/home.mdx
+++ b/docs.joern.io/docs/home.mdx
@@ -45,7 +45,7 @@ The core features of Joern are:
    the propagation of attacker-controlled data in the code to be analyzed
    statically.
 
-- **Search Queries.** Joern offers a stronly-typed Scala-based extensible
+- **Search Queries.** Joern offers a strongly-typed Scala-based extensible
   query language for code analysis based on Gremlin-Scala. This language	
   can be used to manually formulate search queries for vulnerabilities
   as well as automatically infer them using machine learning


### PR DESCRIPTION
changes `stronly` to `strongly`