### PR TITLE
quick typos

### DIFF
--- a/docs.joern.io/content/frontends/java.md
+++ b/docs.joern.io/content/frontends/java.md
@@ -48,7 +48,7 @@ CallNode
     ├── Argument[0]: this 
     ├── Argument[1]: param1
     ├── Argument[2]: param2
-    └── Argument[3]: parma3
+    └── Argument[3]: param3
 ```
 Note that the method signature in the Java code only has three arguments, but the call AST has four. There is an implicit argument that is added in the 0th position, which is the `receiver` of the call node. In this case since the call is invoking a method defined in the same class, so an implicit `this` argument is added at `arg[0]` as the `receiver` of the call. Note that dynamic methods (i.e methods without the `static` modifier) also have a `this` 0th parameter that lines up with the `this` 0th argument in the `CallNode`.
 

--- a/docs.joern.io/content/frontends/javascript.md
+++ b/docs.joern.io/content/frontends/javascript.md
@@ -37,7 +37,7 @@ CallNode
     ├── Argument[0]: this 
     ├── Argument[1]: param1
     ├── Argument[2]: param2
-    └── Argument[3]: parma3
+    └── Argument[3]: param3
 ```
 Simple calls are modelled slightly different in dynamic languages (such as JavaScript) when compared to static languages. In dynamic languages `arg[0]` is no longer the receiver of the call, but instead is the object that holds the property which is the receiver of the call. There is also a 5th argument introduced, which is `arg[-1]`.
 

--- a/docs.joern.io/content/frontends/python.md
+++ b/docs.joern.io/content/frontends/python.md
@@ -40,7 +40,7 @@ CallNode
     ├── Argument[0]: self 
     ├── Argument[1]: param1
     ├── Argument[2]: param2
-    └── Argument[3]: parma3
+    └── Argument[3]: param3
 ```
 Simple calls are modelled slightly different in dynamic languages (such as Python) when compared to static languages. In dynamic languages `arg[0]` is no longer the receiver of the call, but instead is the object that holds the property which is the receiver of the call. There is also a 5th argument introduced, which is `arg[-1]`. In Python, the `self` argument is the same as the `this` argument in other languages.
 


### PR DESCRIPTION
Other than `parma` -> `param`, the other change is just an extra NL to end the file.