### PR TITLE
Fix broken links, etc.

### DIFF
--- a/docs.joern.io/content/c-syntaxtree.md
+++ b/docs.joern.io/content/c-syntaxtree.md
@@ -87,7 +87,7 @@ pair `(name,attribute)`.
 
 ## Basic AST Traversals
 
-The most basic [traversal](traversal-basics) that you can
+The most basic [traversal](/traversal-basics) that you can
 execute on any AST node is `ast`, which traverses to all nodes of the
 AST rooted in the node. For example,
 

--- a/docs.joern.io/content/code-property-graph.md
+++ b/docs.joern.io/content/code-property-graph.md
@@ -23,7 +23,7 @@ replaced both the storage backend and query language with our own
 graph database
 [OverflowDB](https://github.com/ShiftLeftSecurity/overflowdb).
 
-ShiftLeft has open-sourced the [implementation of the code property
+Qwiet AI (formerly ShiftLeft) has open-sourced the [implementation of the code property
 graph](https://github.com/ShiftLeftSecurity/codepropertygraph) and its
 [specification](https://cpg.joern.io).
 

--- a/docs.joern.io/content/code-property-graph.md
+++ b/docs.joern.io/content/code-property-graph.md
@@ -9,7 +9,7 @@ codebases for instances of programming patterns. These patterns are
 formulated in a domain-specific language (DSL) based on
 [Scala](https://www.scala-lang.org/). It serves as a single
 intermediate program representation across all languages supported by
-Joern and its commercial brother [Ocular](https://www.shifleft.io/).
+Joern and its commercial brother [Ocular](https://qwiet.ai/).
 
 Property graphs are a generic abstraction supported by many
 contemporary graph databases such as [Neo4j](https://neo4j.com/),

--- a/docs.joern.io/content/extensions.md
+++ b/docs.joern.io/content/extensions.md
@@ -177,6 +177,6 @@ val exampleNode = builder.addNodeType(
 cpgSchema.base.file.addProperties(exampleProperty)
 ```
 
-The schema is defined in overflowdb-schema, which is a Scala DSL. I.e. you can open `sample-plugin` in your favorite IDE (we recommend Intellij Idea) and get autocompletion, compiler feedback etc., which should help with creating your schema extension. For more inspiration you could explore the base cpg schema definition which is split across multiple files for modularity: https://github.com/ShiftLeftSecurity/codepropertygraph/tree/master/schema/src/main/scala/io/shiftleft/codepropertygraph/schema
+The schema is defined in overflowdb-schema, which is a Scala DSL. I.e. you can open `sample-plugin` in your favorite IDE (we recommend IntelliJ IDEA) and get autocompletion, compiler feedback etc., which should help with creating your schema extension. For more inspiration you could explore the base cpg schema definition which is split across multiple files for modularity: https://github.com/ShiftLeftSecurity/codepropertygraph/tree/master/schema/src/main/scala/io/shiftleft/codepropertygraph/schema
 
 To generate the domain classes and install the schema extension in your joern distribution (must be installed first), simply run `./install.sh` in the sample-plugin. 

--- a/docs.joern.io/content/quickstart.md
+++ b/docs.joern.io/content/quickstart.md
@@ -267,7 +267,7 @@ joern> :exit
 
 Congratulations, you have successfully queried your first  Code
 Property Graph using Joern and its query language. More examples can be found on the
-[query-database website](http://queries.joern.io) (also see [Joern Scan](scan.md)).
+[query-database website](http://queries.joern.io) (also see [Joern Scan](/scan.md)).
 
 In subsequent articles, you will learn the more advanced features of Joern and also
 how to use it to find your first real-world vulnerability.

--- a/docs.joern.io/content/traversal-basics.md
+++ b/docs.joern.io/content/traversal-basics.md
@@ -6,7 +6,7 @@ weight: 40
 
 Joern helps you discover security vulnerabilities by executing graph
 traversals on the [Code Property
-Graph](code-property-graph). A traversal is formulated
+Graph](/code-property-graph). A traversal is formulated
 as an _Joern Query_, or _query_ for short. In this article, you will learn about the different components that make up queries.
 
 ## The Anatomy of a Joern Query


### PR DESCRIPTION
* Fix broken links (generally just missing a leading slash (`/`). Also replace Ocular link (from shiftleft.io to qwiet.ai)
* Fix a few typos, branding (e.g. Intellij Idea -> IntelliJ IDEA), etc.
* Rebrand one instance of ShiftLeft to Qwiet AI
