### PR TITLE
upgrade github actions plugins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
             --minify \
             --baseURL "https://docs.joern.io/"
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./docs.joern.io/public
 


### PR DESCRIPTION
the build failed with

```
Download action repository 'actions/upload-pages-artifact@v1' (SHA:84bb4cd4b733d5c320c9c9cfbc354937524f4d64)
Getting action download info
Error: Missing download info for actions/upload-artifact@v3
```
https://github.com/joernio/website/actions/runs/13837373766/job/38715747694

upload-artifact@v3 is deprecated (see
https://github.com/marketplace/actions/upload-a-build-artifact).
We don't use it directory, but I guess it's used by
`upload-pages-artifact` - so trying to update that one...