### PR TITLE
Fix scan URL in quickstart

### DIFF
--- a/docs.joern.io/content/quickstart.md
+++ b/docs.joern.io/content/quickstart.md
@@ -267,7 +267,7 @@ joern> :exit
 
 Congratulations, you have successfully queried your first  Code
 Property Graph using Joern and its query language. More examples can be found on the
-[query-database website](http://queries.joern.io) (also see [Joern Scan](/scan.md)).
+[query-database website](http://queries.joern.io) (also see [Joern Scan](/scan)).
 
 In subsequent articles, you will learn the more advanced features of Joern and also
 how to use it to find your first real-world vulnerability.


### PR DESCRIPTION
The current URL to scan is `/scan.md` but the working URL is https://docs.joern.io/scan/